### PR TITLE
fix buttons don't get disabled #12

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -12,7 +12,7 @@ module.exports = {
           );
           return (
             contentWithoutStyleBlocks.match(
-              /[A-Za-z0-9-_/:]*[A-Za-z0-9-_/]+/g
+              /[A-Za-z0-9-_/]*[A-Za-z0-9-_/]+/g
             ) || []
           );
         },
@@ -20,8 +20,8 @@ module.exports = {
           /-(leave|enter|appear)(|-(to|from|active))$/,
           /^(?!(|.*?:)cursor-move).+-move$/,
           /^router-link(|-exact)-active$/,
-          /data-v-.*/,
-        ],
+          /data-v-.*/
+        ]
       }),
   ],
 };


### PR DESCRIPTION
I found an error in the default PurgeCSS configuration generated from the official vue plugin. I fix it, so button are correctly disabled again.