### PR TITLE
Add delete timer possibility

### DIFF
--- a/src/components/Timers.vue
+++ b/src/components/Timers.vue
@@ -10,12 +10,19 @@
     </div>
     <div class="column">
       <template v-if="deleteMode">
-        <button class="button is-danger" v-on:click="deleteTimer(id)"><b-icon icon="delete"></b-icon></button>
+        <template v-if="t.state === 'running'">
+          <b-tooltip label="Cannot delete a running timer" position="is-bottom">
+            <button class="button is-danger" disabled><b-icon icon="delete"></b-icon></button>
+          </b-tooltip>
+        </template>
+        <template v-else>
+            <button class="button is-danger" v-on:click="deleteTimer(id)"><b-icon icon="delete"></b-icon></button>
+        </template>
       </template>
       <template v-else>
-        <button class="button is-success" v-on:click="start(id)" :disabled="t.state !== 'running' ? false : true"><b-icon icon="play"></b-icon></button>
-        <button class="button is-warning" v-on:click="pause(id)" :disabled="t.state === 'running' ? false: true"><b-icon icon="pause"></b-icon></button>
-        <button class="button is-danger" v-on:click="reset(id)" :disabled="t.state === 'paused' ? false: true"><b-icon icon="restart"></b-icon></button>
+        <button class="button is-success" v-on:click="start(id)" :disabled="t.state === 'running'"><b-icon icon="play"></b-icon></button>
+        <button class="button is-warning" v-on:click="pause(id)" :disabled="t.state !== 'running'"><b-icon icon="pause"></b-icon></button>
+        <button class="button is-danger" v-on:click="reset(id)" :disabled="t.state !== 'paused'"><b-icon icon="restart"></b-icon></button>
       </template>
     </div>
   </div>

--- a/src/components/Timers.vue
+++ b/src/components/Timers.vue
@@ -9,12 +9,23 @@
       {{ toHHMMSS(t.runTime) }}
     </div>
     <div class="column">
-      <button class="button is-success" v-on:click="start(id)" :disabled="t.state !== 'running' ? false : true"><b-icon icon="play"></b-icon></button>
-      <button class="button is-warning" v-on:click="pause(id)" :disabled="t.state === 'running' ? false: true"><b-icon icon="pause"></b-icon></button>
-      <button class="button is-danger" v-on:click="reset(id)" :disabled="t.state === 'paused' ? false: true"><b-icon icon="restart"></b-icon></button>
+      <template v-if="deleteMode">
+        <button class="button is-danger" v-on:click="deleteTimer(id)"><b-icon icon="delete"></b-icon></button>
+      </template>
+      <template v-else>
+        <button class="button is-success" v-on:click="start(id)" :disabled="t.state !== 'running' ? false : true"><b-icon icon="play"></b-icon></button>
+        <button class="button is-warning" v-on:click="pause(id)" :disabled="t.state === 'running' ? false: true"><b-icon icon="pause"></b-icon></button>
+        <button class="button is-danger" v-on:click="reset(id)" :disabled="t.state === 'paused' ? false: true"><b-icon icon="restart"></b-icon></button>
+      </template>
     </div>
   </div>
-  <button class="button is-primary" v-on:click="addTimer"><b-icon icon="plus"></b-icon></button>
+  <template v-if="deleteMode">
+    <button class="button is-primary" v-on:click="disableDeleteMode"><b-icon icon="check"></b-icon><span>Finish</span></button>
+  </template>
+  <template v-else>
+    <button class="button is-primary" v-on:click="addTimer"><b-icon icon="plus"></b-icon></button>
+    <button class="button is-danger" v-on:click="enableDeleteMode"><b-icon icon="delete"></b-icon></button>
+  </template>
 </div>
 </template>
 
@@ -34,6 +45,7 @@ export default {
   name: 'Timers',
   data () {
     return {
+      deleteMode: false,
       timer: {
         0: newTimer(),
       }
@@ -69,9 +81,17 @@ export default {
       this.timer[id].runTime += 1
     },
     addTimer: function () {
-      const l = Object.keys(this.timer).length
-      console.log('lol')
-      this.$set(this.timer, l, newTimer())
+      const l = Object.keys(this.timer).length;
+      this.$set(this.timer, l, newTimer());
+    },
+    deleteTimer: function (id) {
+      this.$delete(this.timer, id);
+    },
+    enableDeleteMode: function () {
+      this.deleteMode = true;
+    },
+    disableDeleteMode: function () {
+      this.deleteMode = false;
     },
     saveState: throttle(function () {
       localStorage.setItem('timetrackr.timer-state', JSON.stringify(this.timer));

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,11 @@
 import Vue from 'vue'
 import App from './App.vue'
-import { Icon } from 'buefy'
+import { Icon, Tooltip } from 'buefy'
 import 'buefy/dist/buefy.css'
 import router from './router'
 
 Vue.use(Icon)
+Vue.use(Tooltip)
 
 Vue.config.productionTip = false
 


### PR DESCRIPTION
I continue to think about what I made and I think it could be usefull to offer a delete timer possibility as for now we restore the previous state so we can only reset a timer not have less timer.

To stay very simple and avoid deleting timer with a misclick, I add a delete button beside the add button. A click on this delete button switch the view to delete mode. This mode hide start/pause/reset button to show a delete button, which will delete on one click the timer. When finished to delete timers, we can click on finish button (which replace add/delete button on the normal view).

What do you think of this feature?
I directly made a PR, this way you can directly play with this on the Netlify demo version :slightly_smiling_face: 